### PR TITLE
Fix "Column `output_dir` not found in `.data`"

### DIFF
--- a/R/query.R
+++ b/R/query.R
@@ -85,7 +85,7 @@ get_SingleCellExperiment <- function(
     inherits(raw_data, "tbl") |> assert_that()
     has_name(raw_data, c("_cell", "file_id_db")) |> assert_that()
 
-    versioned_cache_directory = file.path(cache_directory, COUNTS_VERSION)
+    versioned_cache_directory <- file.path(cache_directory, COUNTS_VERSION)
     versioned_cache_directory |> dir.create(showWarnings = FALSE, recursive = TRUE)
 
     subdirs <- assay_map[assays]


### PR DESCRIPTION
Fixes:
```
Error in `transmute()`:
! Problem while computing `..3 = output_file <- file.path(.data$output_dir, .data$filename)`.
Caused by error in `.data$output_dir`:
! Column `output_dir` not found in `.data`.
Run `rlang::last_error()` to see where the error occurred.
```