### PR TITLE
Enable use_cache = FALSE for get_metadata()

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -154,12 +154,12 @@ get_metadata <- function(
     else {
         db_path <- file.path(cache_directory, "metadata.0.2.3.parquet")
         
-            report_file_sizes(remote_url)
-            sync_remote_file(
-                remote_url,
-                db_path,
-                progress(type = "down", con = stderr())
-            )
+          report_file_sizes(remote_url)
+          sync_remote_file(
+              remote_url,
+              db_path,
+              progress(type = "down", con = stderr())
+          )
 
         table <- duckdb() |>
             dbConnect(drv = _, read_only = TRUE) |>

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -154,14 +154,12 @@ get_metadata <- function(
     else {
         db_path <- file.path(cache_directory, "metadata.0.2.3.parquet")
         
-        #if (!file.exists(db_path)){
             report_file_sizes(remote_url)
             sync_remote_file(
                 remote_url,
                 db_path,
                 progress(type = "down", con = stderr())
             )
-        #}
 
         table <- duckdb() |>
             dbConnect(drv = _, read_only = TRUE) |>

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -154,14 +154,14 @@ get_metadata <- function(
     else {
         db_path <- file.path(cache_directory, "metadata.0.2.3.parquet")
         
-        if (!file.exists(db_path)){
+        #if (!file.exists(db_path)){
             report_file_sizes(remote_url)
             sync_remote_file(
                 remote_url,
                 db_path,
                 progress(type = "down", con = stderr())
             )
-        }
+        #}
 
         table <- duckdb() |>
             dbConnect(drv = _, read_only = TRUE) |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -61,7 +61,11 @@ get_default_cache_dir <- function() {
 #' @return `NULL`, invisibly
 #' @keywords internal
 sync_remote_file <- function(full_url, output_file, ...) {
-    if (!file.exists(output_file)) {
+    user_over <- NA
+    if (file.exists(output_file)) {
+      user_over <- tolower(readline(prompt = "Cached file already exists. Overwrite? (Y/N):"))
+    }
+    if (!file.exists(output_file) | user_over == "y") {
         output_dir <- dirname(output_file)
         dir.create(output_dir,
                    recursive = TRUE,
@@ -70,7 +74,7 @@ sync_remote_file <- function(full_url, output_file, ...) {
         cli_alert_info("Downloading {full_url} to {output_file}")
         
         tryCatch(
-            GET(full_url, write_disk(output_file), ...) |> stop_for_status(),
+            GET(full_url, write_disk(output_file, overwrite = TRUE), ...) |> stop_for_status(),
             error = function(e) {
                 # Clean up if we had an error
                 file.remove(output_file)


### PR DESCRIPTION
ISSUE: metadata.R/`get_metadata(use_cache = FALSE)` was still using the cached file due to multiple `if (!file.exists())` bypasses

ADJUSTED:

- utils.R/`sync_remote_file()` adjusted to get user permission to overwrite if cached file exists
- metadata.R/`get_metadata()` adjusted to push all `file.exists()` checking to utils.R/`sync_remote_file()`
